### PR TITLE
throw exception if site folder doesn't exist

### DIFF
--- a/src/docfx/SubCommands/ServeCommand.cs
+++ b/src/docfx/SubCommands/ServeCommand.cs
@@ -35,6 +35,10 @@ namespace Microsoft.DocAsCode.SubCommands
             folder = Path.GetFullPath(folder);
             port = string.IsNullOrWhiteSpace(port) ? "8080" : port;
             var url = $"http://localhost:{port}";
+            if (!Directory.Exists(folder))
+            {
+                throw new ArgumentException("Site folder does not exist. You may need to build it first. Example: \"docfx docfx_project/docfx.json\"", nameof(folder));
+            }
             var fileServerOptions = new FileServerOptions
             {
                 EnableDirectoryBrowsing = true,


### PR DESCRIPTION
If the passed in site folder doesn't exist (user forgot to run build command), throw a useful exception instead of a DirectoryNotFound.

![image](https://cloud.githubusercontent.com/assets/1006516/14662720/f6254f02-0686-11e6-9f0d-60559b40f0cc.png)


![image](https://cloud.githubusercontent.com/assets/1006516/14662718/f0d4bb0a-0686-11e6-997a-9f5554c93f10.png)
